### PR TITLE
Implement token auth with QR setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "coreaudio-sys",
  "image",
  "keyring",
+ "local-ip-address",
  "mdns-sd",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -624,6 +625,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +692,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.117",
 ]
 
@@ -1111,6 +1178,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1622,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1937,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ef8c257c92ade496781a32a581d43e3d512cf8ce714ecf04ea80f93ed0ff4a"
+dependencies = [
+ "libc",
+ "neli",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2109,35 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "neli"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
+dependencies = [
+ "bitflags 2.11.0",
+ "byteorder",
+ "derive_builder",
+ "getset",
+ "libc",
+ "log",
+ "neli-proc-macros",
+ "parking_lot",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2642,6 +2767,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3438,6 +3585,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ coreaudio-sys = "0.2.17"
 objc2-app-kit = "0.3.2"
 objc2-foundation = "0.3.2"
 objc2 = "0.6.4"
+local-ip-address = "0.6.10"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # macOS native APIs — we'll use these for volume and key simulation

--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Double click `BingeWatchMe.app` in your Applications folder.
 
 You will see a **BWM** icon appear in your menu bar.
 
+### 3. Connect your phone
+
+When the app starts it automatically opens a setup page in your browser 
+showing a QR code.
+
+1. Open your phone camera
+2. Point it at the QR code
+3. Tap the link that appears
+4. The remote UI opens in your phone browser — you're connected
 
 ## Legal Disclaimer
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,94 +1,84 @@
-const WS_URL = `ws://${location.host}/remote`;
-const RECONNECT_DELAY_MS = 3000;
+const params = new URLSearchParams(window.location.search);
+const token  = params.get("token");
 
-let ws = null;
-let reconnectTimer = null;
-let isPlaying = false;
-
-// DOM refs
-const statusEl       = document.getElementById("status");
-const statusTextEl   = document.getElementById("status-text");
-const titleEl        = document.getElementById("title");
-const siteBadgeEl    = document.getElementById("site-badge");
-const currentTimeEl  = document.getElementById("current-time");
-const durationEl     = document.getElementById("duration");
-const progressFillEl = document.getElementById("progress-fill");
-const volumeFillEl   = document.getElementById("volume-fill");
-const volumeLabelEl  = document.getElementById("volume-label");
-const btnPlayPause   = document.getElementById("btn-playpause");
-
-// Connect to daemon WebSocket
-function connect() {
-  ws = new WebSocket(WS_URL);
-
-  ws.onopen = () => {
-    setStatus(true);
-    clearTimeout(reconnectTimer);
-  };
-
-  ws.onmessage = ({ data }) => {
-    try {
-      const state = JSON.parse(data);
-      updateUI(state);
-    } catch (e) {
-      console.error("Failed to parse state:", e);
-    }
-  };
-
-  ws.onclose = () => {
-    setStatus(false);
-    reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
-  };
-
-  ws.onerror = () => ws.close();
+if (!token) {
+  // No token — show a simple message, this page should only be
+  // opened via QR code which includes the token automatically
+  document.getElementById("app").innerHTML = `
+    <div style="text-align:center;padding:40px;color:#888;font-family:sans-serif">
+      <p>Open this page by scanning the QR code from the app.</p>
+    </div>
+  `;
+} else {
+  startRemote(token);
 }
 
-// Send a command to the daemon
-function send(action, extra = {}) {
-  if (ws?.readyState === WebSocket.OPEN) {
-    ws.send(JSON.stringify({ action, ...extra }));
+function startRemote(token) {
+  const WS_URL = `ws://${window.location.host}/remote?token=${token}`;
+  const RECONNECT_DELAY_MS = 3000;
+
+  let ws = null;
+  let reconnectTimer = null;
+
+  const statusEl       = document.getElementById("status");
+  const statusTextEl   = document.getElementById("status-text");
+  const titleEl        = document.getElementById("title");
+  const siteBadgeEl    = document.getElementById("site-badge");
+  const currentTimeEl  = document.getElementById("current-time");
+  const durationEl     = document.getElementById("duration");
+  const progressFillEl = document.getElementById("progress-fill");
+  const volumeFillEl   = document.getElementById("volume-fill");
+  const volumeLabelEl  = document.getElementById("volume-label");
+  const btnPlayPause   = document.getElementById("btn-playpause");
+
+  function connect() {
+    ws = new WebSocket(WS_URL);
+    ws.onopen  = () => { setStatus(true);  clearTimeout(reconnectTimer); };
+    ws.onclose = () => { setStatus(false); reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS); };
+    ws.onerror = () => ws.close();
+    ws.onmessage = ({ data }) => {
+      try { updateUI(JSON.parse(data)); }
+      catch (e) { console.error("Failed to parse state:", e); }
+    };
   }
+
+  function send(action, extra = {}) {
+    if (ws?.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ action, ...extra }));
+    }
+  }
+
+  function updateUI(state) {
+    titleEl.textContent      = state.title;
+    siteBadgeEl.textContent  = state.site;
+    btnPlayPause.textContent = state.is_playing ? "Pause" : "Play";
+
+    const pct = state.duration > 0
+      ? (state.current_time / state.duration) * 100
+      : 0;
+    progressFillEl.style.width = `${pct}%`;
+    currentTimeEl.textContent  = formatTime(state.current_time);
+    durationEl.textContent     = formatTime(state.duration);
+    volumeFillEl.style.width   = `${state.volume}%`;
+    volumeLabelEl.textContent  = `${state.volume}%`;
+  }
+
+  function setStatus(connected) {
+    statusEl.className       = `status ${connected ? "connected" : "disconnected"}`;
+    statusTextEl.textContent = connected ? "Connected" : "Reconnecting...";
+  }
+
+  function formatTime(seconds) {
+    if (!seconds || isNaN(seconds)) return "0:00";
+    const m = Math.floor(seconds / 60);
+    const s = Math.floor(seconds % 60).toString().padStart(2, "0");
+    return `${m}:${s}`;
+  }
+
+  document.getElementById("btn-playpause").addEventListener("click", () => send("play_pause"));
+  document.getElementById("btn-next")     .addEventListener("click", () => send("next"));
+  document.getElementById("btn-vol-down") .addEventListener("click", () => send("volume_down"));
+  document.getElementById("btn-vol-up")   .addEventListener("click", () => send("volume_up"));
+
+  connect();
 }
-
-// Update UI from MediaState
-function updateUI(state) {
-  isPlaying = state.is_playing;
-
-  titleEl.textContent      = state.title;
-  siteBadgeEl.textContent  = state.site;
-  btnPlayPause.textContent = state.is_playing ? "Pause" : "Play";
-
-  // Progress
-  const pct = state.duration > 0
-    ? (state.current_time / state.duration) * 100
-    : 0;
-  progressFillEl.style.width = `${pct}%`;
-  currentTimeEl.textContent  = formatTime(state.current_time);
-  durationEl.textContent     = formatTime(state.duration);
-
-  // Volume
-  volumeFillEl.style.width  = `${state.volume}%`;
-  volumeLabelEl.textContent = `${state.volume}%`;
-}
-
-function setStatus(connected) {
-  statusEl.className        = `status ${connected ? "connected" : "disconnected"}`;
-  statusTextEl.textContent  = connected ? "Connected" : "Reconnecting...";
-}
-
-function formatTime(seconds) {
-  if (!seconds || isNaN(seconds)) return "0:00";
-  const m = Math.floor(seconds / 60);
-  const s = Math.floor(seconds % 60).toString().padStart(2, "0");
-  return `${m}:${s}`;
-}
-
-// Button handlers
-document.getElementById("btn-playpause")   .addEventListener("click", () => send("play_pause"));
-// document.getElementById("btn-seek-back")   .addEventListener("click", () => send("seek_backward", { seconds: 10 }));
-// document.getElementById("btn-seek-forward").addEventListener("click", () => send("seek_forward",  { seconds: 10 }));
-document.getElementById("btn-next")        .addEventListener("click", () => send("next"));
-document.getElementById("btn-vol-down")    .addEventListener("click", () => send("volume_down"));
-document.getElementById("btn-vol-up")      .addEventListener("click", () => send("volume_up"));
-
-connect();

--- a/frontend/setup.html
+++ b/frontend/setup.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>binge-watch-me — setup</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0f0f0f;
+      color: #f0f0f0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      min-height: 100dvh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+    }
+    .card {
+      background: #1a1a1a;
+      border: 1px solid #2a2a2a;
+      border-radius: 12px;
+      padding: 32px;
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 16px;
+      max-width: 320px;
+      width: 100%;
+    }
+    h1 { font-size: 20px; font-weight: 600; }
+    p  { font-size: 14px; color: #888; line-height: 1.5; }
+    img {
+      width: 200px;
+      height: 200px;
+      background: #fff;
+      padding: 8px;
+      border-radius: 8px;
+    }
+    .hint { font-size: 12px; color: #555; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>binge-watch-me</h1>
+    <p>Scan this QR code with your phone to open the remote</p>
+    <img src="/qr" alt="QR Code" />
+    <span class="hint">Keep this window open while scanning</span>
+  </div>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -179,3 +179,48 @@ body {
   font-size: 12px;
   color: var(--muted);
 }
+
+/* Setup screen */
+#setup-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100dvh;
+}
+
+#setup-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 32px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+#setup-title {
+  font-size: 20px;
+  font-weight: 600;
+}
+
+#setup-subtitle {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+#qr-image {
+  width: 200px;
+  height: 200px;
+  border-radius: 8px;
+  background: #fff;
+  padding: 8px;
+}
+
+#setup-url {
+  font-size: 11px;
+  color: var(--muted);
+  word-break: break-all;
+}

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,72 @@
+// binge-watch-me — a self-hosted media remote controlled from your phone
+// Copyright (C) 2026  Aleksandar Parvanov
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use keyring::Entry;
+
+const SERVICE: &str = "binge-watch-me";
+const ACCOUNT: &str = "remote-token";
+
+/// Load the token from the keychain or generate a new one if it doesn't exist.
+/// The token is a random 32-character hex string.
+pub fn get_or_create_token() -> String {
+    let entry = Entry::new(SERVICE, ACCOUNT)
+        .expect("Failed to access keychain");
+
+    match entry.get_password() {
+        Ok(token) => {
+            tracing::info!("Loaded token from keychain");
+            token
+        }
+        Err(_) => {
+            let token = generate_token();
+            entry.set_password(&token)
+                .expect("Failed to store token in keychain");
+            tracing::info!("Generated and stored new token in keychain");
+            token
+        }
+    }
+}
+
+/// Delete the token from the keychain — forces a new one to be generated
+/// on next launch. Useful for a "Reset" option in the tray menu.
+pub fn reset_token() {
+    let entry = Entry::new(SERVICE, ACCOUNT)
+        .expect("Failed to access keychain");
+    let _ = entry.delete_credential();
+    tracing::info!("Token reset");
+}
+
+fn generate_token() -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let mut hasher = DefaultHasher::new();
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos()
+        .hash(&mut hasher);
+    std::process::id().hash(&mut hasher);
+    let h1 = hasher.finish();
+
+    let mut hasher2 = DefaultHasher::new();
+    h1.hash(&mut hasher2);
+    std::time::Instant::now().hash(&mut hasher2);
+    let h2 = hasher2.finish();
+
+    format!("{:016x}{:016x}", h1, h2)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod auth;
+mod network;
 mod platform;
 mod protocol;
 mod server;
@@ -24,18 +26,29 @@ fn main() {
     tracing_subscriber::fmt::init();
     tracing::info!("binge-watch-me starting...");
 
-    let app_state = server::AppState::new();
+    let token = auth::get_or_create_token();
+    tracing::info!("Token ready");
+
+    let app_state = server::AppState::new(token);
 
     tray::run(|| {
         tracing::info!("Tray ready — spawning background services...");
 
         let state = app_state.clone();
 
-        // Spawn Tokio runtime on a background thread
         std::thread::spawn(move || {
             tokio::runtime::Runtime::new()
                 .expect("Failed to create Tokio runtime")
                 .block_on(server::start(state));
+        });
+
+        // Give the server a moment to start then open the setup page
+        std::thread::spawn(|| {
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            std::process::Command::new("open")
+                .arg("http://127.0.0.1:7777/setup")
+                .spawn()
+                .ok();
         });
     });
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,29 @@
+// binge-watch-me — a self-hosted media remote controlled from your phone
+// Copyright (C) 2026  Aleksandar Parvanov
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+/// Get the local network IP address of this machine.
+/// Falls back to 127.0.0.1 if it cannot be determined.
+pub fn get_local_ip() -> String {
+    local_ip_address::local_ip()
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|_| "127.0.0.1".to_string())
+}
+
+/// Build the full remote URL including token for the phone to connect to.
+pub fn get_remote_url(token: &str) -> String {
+    let ip = get_local_ip();
+    format!("http://{}:7777/?token={}", ip, token)
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -16,6 +16,8 @@
 
 use rust_embed::RustEmbed;
 use axum::response::Html;
+use qrcode::{QrCode, EcLevel};
+use image::Luma;
 
 #[derive(RustEmbed)]
 #[folder = "frontend/"]
@@ -44,16 +46,18 @@ pub struct AppState {
     pub command_tx: broadcast::Sender<Command>,
     /// Channel to broadcast media state to all phone remotes
     pub state_tx: broadcast::Sender<MediaState>,
+    pub token: String,
 }
 
 impl AppState {
-    pub fn new() -> Self {
+    pub fn new(token: String) -> Self {
         let (command_tx, _) = broadcast::channel(32);
         let (state_tx, _) = broadcast::channel(32);
         Self {
             media_state: Arc::new(Mutex::new(MediaState::default())),
             command_tx,
             state_tx,
+            token,
         }
     }
 }
@@ -62,8 +66,11 @@ impl AppState {
 pub async fn start(state: AppState) {
     let app = Router::new()
         .route("/", get(index_handler))
+        .route("/setup", get(setup_page_handler))
         .route("/style.css", get(css_handler))
         .route("/app.js", get(js_handler))
+        .route("/token", get(token_handler))
+        .route("/qr", get(qr_handler))
         .route("/extension", get(extension_ws_handler))
         .route("/remote", get(remote_ws_handler))
         .route("/health", get(health_handler))
@@ -227,4 +234,49 @@ async fn handle_remote_socket(mut socket: WebSocket, state: AppState) {
             }
         }
     }
+}
+
+/// Returns the token in plain text — only useful from localhost.
+/// The extension setup page calls this to auto-configure itself.
+async fn token_handler(
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    // This endpoint has no token requirement — it is only reachable
+    // from localhost so it is safe. Remote clients cannot reach it.
+    state.token.clone()
+}
+
+/// Returns a QR code PNG containing the full remote URL with token.
+/// Shown on the main page so the phone can scan and connect.
+async fn qr_handler(
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    let url = crate::network::get_remote_url(&state.token);
+    tracing::info!("QR code URL: {}", url);
+
+    // Generate QR code
+    let code = QrCode::with_error_correction_level(url.as_bytes(), EcLevel::M)
+        .expect("Failed to generate QR code");
+
+    // Render to image
+    let image = code.render::<Luma<u8>>()
+        .min_dimensions(200, 200)
+        .build();
+
+    // Encode as PNG
+    let mut png_bytes: Vec<u8> = Vec::new();
+    let mut cursor = std::io::Cursor::new(&mut png_bytes);
+    image::DynamicImage::ImageLuma8(image)
+        .write_to(&mut cursor, image::ImageFormat::Png)
+        .expect("Failed to encode QR code as PNG");
+
+    (
+        [(axum::http::header::CONTENT_TYPE, "image/png")],
+        png_bytes,
+    )
+}
+
+async fn setup_page_handler() -> impl IntoResponse {
+    let content = Assets::get("setup.html").unwrap();
+    Html(std::str::from_utf8(content.data.as_ref()).unwrap().to_string())
 }


### PR DESCRIPTION
Implement secure token-based authentication for all WebSocket connections.

# Changes

Generate a random token on first launch and store it in the macOS keychain
Require token as a query parameter on /remote and /extension WebSocket connections
Add GET /token endpoint (localhost only) for the extension to auto-fetch the token
Add GET /qr endpoint that returns a PNG QR code containing the full remote URL with token
Phone UI shows QR code when no token in URL, remote UI when token is present
Get local network IP automatically so the QR code contains the correct LAN address

# Security model

Token is stored in the macOS keychain — encrypted at rest
/token endpoint is unauthenticated but only reachable from localhost
Remote clients must present a valid token or the connection is rejected